### PR TITLE
Fix "Cannot use import statement outside a module"

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "tailwindcss-group-modifier-plugin",
   "version": "0.1.1",
   "description": "",
+  "type": "module",
   "main": "dist/index.js",
   "scripts": {
     "test": "vitest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwindcss-group-modifier-plugin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
/Users/.../myproject/node_modules/tailwindcss-group-modifier-plugin/dist/index.js:1
import plugin from "tailwindcss/plugin";
^^^^^^

SyntaxError: Cannot use import statement outside a module